### PR TITLE
feat: allow annotations to be set at dygraph init

### DIFF
--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -997,7 +997,7 @@ if (typeof process !== "undefined") {
 
     // Do a quick sanity check on the options reference.
     var warn = function (msg) {
-      if (window?.console) window?.console.warn(msg);
+      if (window.console) window.console.warn(msg);
     };
     var flds = ["type", "default", "description"];
     var valid_cats = [

--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -119,7 +119,7 @@ export function removeEvent(elem, type, fn) {
  * @private
  */
 export function cancelEvent(e) {
-  e = e ? e : window?.event;
+  e = e ? e : window.event;
   if (e.stopPropagation) {
     e.stopPropagation();
   }
@@ -704,7 +704,7 @@ export function createCanvas() {
  */
 export function getContextPixelRatio(context) {
   try {
-    var devicePixelRatio = window?.devicePixelRatio;
+    var devicePixelRatio = window.devicePixelRatio;
     var backingStoreRatio =
       context.webkitBackingStorePixelRatio ||
       context.mozBackingStorePixelRatio ||
@@ -798,13 +798,13 @@ export function createIterator(array, start, length, opt_predicate) {
 //   Dygraph.requestAnimFrame.call(window, function() {})
 export var requestAnimFrame = (function () {
   return (
-    window?.requestAnimationFrame ||
-    window?.webkitRequestAnimationFrame ||
-    window?.mozRequestAnimationFrame ||
-    window?.oRequestAnimationFrame ||
-    window?.msRequestAnimationFrame ||
+    window.requestAnimationFrame ||
+    window.webkitRequestAnimationFrame ||
+    window.mozRequestAnimationFrame ||
+    window.oRequestAnimationFrame ||
+    window.msRequestAnimationFrame ||
     function (callback) {
-      window?.setTimeout(callback, 1000 / 60);
+      window.setTimeout(callback, 1000 / 60);
     }
   );
 })();
@@ -1085,7 +1085,7 @@ export function toRGB_(colorStr) {
   div.style.backgroundColor = colorStr;
   div.style.visibility = "hidden";
   document.body.appendChild(div);
-  var rgbStr = window?.getComputedStyle(div, null).backgroundColor;
+  var rgbStr = window.getComputedStyle(div, null).backgroundColor;
   document.body.removeChild(div);
   return parseRGBA(rgbStr);
 }

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -82,7 +82,8 @@ import RangeSelectorPlugin from "./plugins/range-selector";
  * options, see http://dygraphs.com/options.html.
  */
 var Dygraph = function (div, data, opts) {
-  if (window) { // We only want to load this in the browser
+  if (window) {
+    // We only want to load this in the browser
     this.__init__(div, data, opts);
   }
 };
@@ -152,6 +153,12 @@ Dygraph.prototype.__init__ = function (div, file, attrs) {
   this.dateWindow_ = attrs.dateWindow || null;
 
   this.annotations_ = [];
+
+  if (attrs.annotations) {
+    this.annotations_ = attrs.annotations;
+  }
+
+  console.log("USING CUSTOM DYGRAPH");
 
   // Clear the div. This ensure that, if multiple dygraphs are passed the same
   // div, then only one will be drawn.
@@ -835,6 +842,9 @@ Dygraph.prototype.createInterface_ = function () {
 
   // Create the grapher
   this.layout_ = new DygraphLayout(this);
+  if (this.annotations) {
+    this.layout_.setAnnotations(this.annotations_);
+  }
 
   var dygraph = this;
 
@@ -3286,7 +3296,7 @@ Dygraph.prototype.start_ = function () {
     } else {
       // REMOVE_FOR_IE
       var req;
-      if (window?.XMLHttpRequest) {
+      if (window.XMLHttpRequest) {
         // Firefox, Opera, IE7, and other browsers will use the native object
         req = new XMLHttpRequest();
       } else {

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -158,8 +158,6 @@ Dygraph.prototype.__init__ = function (div, file, attrs) {
     this.annotations_ = attrs.annotations;
   }
 
-  console.log("USING CUSTOM DYGRAPH");
-
   // Clear the div. This ensure that, if multiple dygraphs are passed the same
   // div, then only one will be drawn.
   div.innerHTML = "";
@@ -842,7 +840,7 @@ Dygraph.prototype.createInterface_ = function () {
 
   // Create the grapher
   this.layout_ = new DygraphLayout(this);
-  if (this.annotations) {
+  if (this.annotations && this.annotations.length) {
     this.layout_.setAnnotations(this.annotations_);
   }
 

--- a/src/extras/smooth-plotter.js
+++ b/src/extras/smooth-plotter.js
@@ -1,140 +1,147 @@
-(function() {
-"use strict";
+(function () {
+  "use strict";
 
-var Dygraph;
-if (window?.Dygraph) {
-  Dygraph = window?.Dygraph;
-} else if (typeof(module) !== 'undefined') {
-  Dygraph = require('../dygraph');
-}
-
-/**
- * Given three sequential points, p0, p1 and p2, find the left and right
- * control points for p1.
- *
- * The three points are expected to have x and y properties.
- *
- * The alpha parameter controls the amount of smoothing.
- * If α=0, then both control points will be the same as p1 (i.e. no smoothing).
- *
- * Returns [l1x, l1y, r1x, r1y]
- *
- * It's guaranteed that the line from (l1x, l1y)-(r1x, r1y) passes through p1.
- * Unless allowFalseExtrema is set, then it's also guaranteed that:
- *   l1y ∈ [p0.y, p1.y]
- *   r1y ∈ [p1.y, p2.y]
- *
- * The basic algorithm is:
- * 1. Put the control points l1 and r1 α of the way down (p0, p1) and (p1, p2).
- * 2. Shift l1 and r2 so that the line l1–r1 passes through p1
- * 3. Adjust to prevent false extrema while keeping p1 on the l1–r1 line.
- *
- * This is loosely based on the HighCharts algorithm.
- */
-function getControlPoints(p0, p1, p2, opt_alpha, opt_allowFalseExtrema) {
-  var alpha = (opt_alpha !== undefined) ? opt_alpha : 1/3;  // 0=no smoothing, 1=crazy smoothing
-  var allowFalseExtrema = opt_allowFalseExtrema || false;
-
-  if (!p2) {
-    return [p1.x, p1.y, null, null];
+  var Dygraph;
+  if (window.Dygraph) {
+    Dygraph = window.Dygraph;
+  } else if (typeof module !== "undefined") {
+    Dygraph = require("../dygraph");
   }
 
-  // Step 1: Position the control points along each line segment.
-  var l1x = (1 - alpha) * p1.x + alpha * p0.x,
+  /**
+   * Given three sequential points, p0, p1 and p2, find the left and right
+   * control points for p1.
+   *
+   * The three points are expected to have x and y properties.
+   *
+   * The alpha parameter controls the amount of smoothing.
+   * If α=0, then both control points will be the same as p1 (i.e. no smoothing).
+   *
+   * Returns [l1x, l1y, r1x, r1y]
+   *
+   * It's guaranteed that the line from (l1x, l1y)-(r1x, r1y) passes through p1.
+   * Unless allowFalseExtrema is set, then it's also guaranteed that:
+   *   l1y ∈ [p0.y, p1.y]
+   *   r1y ∈ [p1.y, p2.y]
+   *
+   * The basic algorithm is:
+   * 1. Put the control points l1 and r1 α of the way down (p0, p1) and (p1, p2).
+   * 2. Shift l1 and r2 so that the line l1–r1 passes through p1
+   * 3. Adjust to prevent false extrema while keeping p1 on the l1–r1 line.
+   *
+   * This is loosely based on the HighCharts algorithm.
+   */
+  function getControlPoints(p0, p1, p2, opt_alpha, opt_allowFalseExtrema) {
+    var alpha = opt_alpha !== undefined ? opt_alpha : 1 / 3; // 0=no smoothing, 1=crazy smoothing
+    var allowFalseExtrema = opt_allowFalseExtrema || false;
+
+    if (!p2) {
+      return [p1.x, p1.y, null, null];
+    }
+
+    // Step 1: Position the control points along each line segment.
+    var l1x = (1 - alpha) * p1.x + alpha * p0.x,
       l1y = (1 - alpha) * p1.y + alpha * p0.y,
       r1x = (1 - alpha) * p1.x + alpha * p2.x,
       r1y = (1 - alpha) * p1.y + alpha * p2.y;
 
-  // Step 2: shift the points up so that p1 is on the l1–r1 line.
-  if (l1x != r1x) {
-    // This can be derived w/ some basic algebra.
-    var deltaY = p1.y - r1y - (p1.x - r1x) * (l1y - r1y) / (l1x - r1x);
-    l1y += deltaY;
-    r1y += deltaY;
-  }
-
-  // Step 3: correct to avoid false extrema.
-  if (!allowFalseExtrema) {
-    if (l1y > p0.y && l1y > p1.y) {
-      l1y = Math.max(p0.y, p1.y);
-      r1y = 2 * p1.y - l1y;
-    } else if (l1y < p0.y && l1y < p1.y) {
-      l1y = Math.min(p0.y, p1.y);
-      r1y = 2 * p1.y - l1y;
+    // Step 2: shift the points up so that p1 is on the l1–r1 line.
+    if (l1x != r1x) {
+      // This can be derived w/ some basic algebra.
+      var deltaY = p1.y - r1y - ((p1.x - r1x) * (l1y - r1y)) / (l1x - r1x);
+      l1y += deltaY;
+      r1y += deltaY;
     }
 
-    if (r1y > p1.y && r1y > p2.y) {
-      r1y = Math.max(p1.y, p2.y);
-      l1y = 2 * p1.y - r1y;
-    } else if (r1y < p1.y && r1y < p2.y) {
-      r1y = Math.min(p1.y, p2.y);
-      l1y = 2 * p1.y - r1y;
+    // Step 3: correct to avoid false extrema.
+    if (!allowFalseExtrema) {
+      if (l1y > p0.y && l1y > p1.y) {
+        l1y = Math.max(p0.y, p1.y);
+        r1y = 2 * p1.y - l1y;
+      } else if (l1y < p0.y && l1y < p1.y) {
+        l1y = Math.min(p0.y, p1.y);
+        r1y = 2 * p1.y - l1y;
+      }
+
+      if (r1y > p1.y && r1y > p2.y) {
+        r1y = Math.max(p1.y, p2.y);
+        l1y = 2 * p1.y - r1y;
+      } else if (r1y < p1.y && r1y < p2.y) {
+        r1y = Math.min(p1.y, p2.y);
+        l1y = 2 * p1.y - r1y;
+      }
     }
+
+    return [l1x, l1y, r1x, r1y];
   }
 
-  return [l1x, l1y, r1x, r1y];
-}
+  // i.e. is none of (null, undefined, NaN)
+  function isOK(x) {
+    return !!x && !isNaN(x);
+  }
 
-// i.e. is none of (null, undefined, NaN)
-function isOK(x) {
-  return !!x && !isNaN(x);
-};
-
-// A plotter which uses splines to create a smooth curve.
-// See tests/plotters.html for a demo.
-// Can be controlled via smoothPlotter.smoothing
-function smoothPlotter(e) {
-  var ctx = e.drawingContext,
+  // A plotter which uses splines to create a smooth curve.
+  // See tests/plotters.html for a demo.
+  // Can be controlled via smoothPlotter.smoothing
+  function smoothPlotter(e) {
+    var ctx = e.drawingContext,
       points = e.points;
 
-  ctx.beginPath();
-  ctx.moveTo(points[0].canvasx, points[0].canvasy);
+    ctx.beginPath();
+    ctx.moveTo(points[0].canvasx, points[0].canvasy);
 
-  // right control point for previous point
-  var lastRightX = points[0].canvasx, lastRightY = points[0].canvasy;
+    // right control point for previous point
+    var lastRightX = points[0].canvasx,
+      lastRightY = points[0].canvasy;
 
-  for (var i = 1; i < points.length; i++) {
-    var p0 = points[i - 1],
+    for (var i = 1; i < points.length; i++) {
+      var p0 = points[i - 1],
         p1 = points[i],
         p2 = points[i + 1];
-    p0 = p0 && isOK(p0.canvasy) ? p0 : null;
-    p1 = p1 && isOK(p1.canvasy) ? p1 : null;
-    p2 = p2 && isOK(p2.canvasy) ? p2 : null;
-    if (p0 && p1) {
-      var controls = getControlPoints({x: p0.canvasx, y: p0.canvasy},
-                                      {x: p1.canvasx, y: p1.canvasy},
-                                      p2 && {x: p2.canvasx, y: p2.canvasy},
-                                      smoothPlotter.smoothing);
-      // Uncomment to show the control points:
-      // ctx.lineTo(lastRightX, lastRightY);
-      // ctx.lineTo(controls[0], controls[1]);
-      // ctx.lineTo(p1.canvasx, p1.canvasy);
-      lastRightX = (lastRightX !== null) ? lastRightX : p0.canvasx;
-      lastRightY = (lastRightY !== null) ? lastRightY : p0.canvasy;
-      ctx.bezierCurveTo(lastRightX, lastRightY,
-                        controls[0], controls[1],
-                        p1.canvasx, p1.canvasy);
-      lastRightX = controls[2];
-      lastRightY = controls[3];
-    } else if (p1) {
-      // We're starting again after a missing point.
-      ctx.moveTo(p1.canvasx, p1.canvasy);
-      lastRightX = p1.canvasx;
-      lastRightY = p1.canvasy;
-    } else {
-      lastRightX = lastRightY = null;
+      p0 = p0 && isOK(p0.canvasy) ? p0 : null;
+      p1 = p1 && isOK(p1.canvasy) ? p1 : null;
+      p2 = p2 && isOK(p2.canvasy) ? p2 : null;
+      if (p0 && p1) {
+        var controls = getControlPoints(
+          { x: p0.canvasx, y: p0.canvasy },
+          { x: p1.canvasx, y: p1.canvasy },
+          p2 && { x: p2.canvasx, y: p2.canvasy },
+          smoothPlotter.smoothing
+        );
+        // Uncomment to show the control points:
+        // ctx.lineTo(lastRightX, lastRightY);
+        // ctx.lineTo(controls[0], controls[1]);
+        // ctx.lineTo(p1.canvasx, p1.canvasy);
+        lastRightX = lastRightX !== null ? lastRightX : p0.canvasx;
+        lastRightY = lastRightY !== null ? lastRightY : p0.canvasy;
+        ctx.bezierCurveTo(
+          lastRightX,
+          lastRightY,
+          controls[0],
+          controls[1],
+          p1.canvasx,
+          p1.canvasy
+        );
+        lastRightX = controls[2];
+        lastRightY = controls[3];
+      } else if (p1) {
+        // We're starting again after a missing point.
+        ctx.moveTo(p1.canvasx, p1.canvasy);
+        lastRightX = p1.canvasx;
+        lastRightY = p1.canvasy;
+      } else {
+        lastRightX = lastRightY = null;
+      }
     }
+
+    ctx.stroke();
   }
+  smoothPlotter.smoothing = 1 / 3;
+  smoothPlotter._getControlPoints = getControlPoints; // for testing
 
-  ctx.stroke();
-}
-smoothPlotter.smoothing = 1/3;
-smoothPlotter._getControlPoints = getControlPoints;  // for testing
-
-// older versions exported a global.
-// This will be removed in the future.
-// The preferred way to access smoothPlotter is via Dygraph.smoothPlotter.
-window?.smoothPlotter = smoothPlotter;
-Dygraph.smoothPlotter = smoothPlotter;
-
+  // older versions exported a global.
+  // This will be removed in the future.
+  // The preferred way to access smoothPlotter is via Dygraph.smoothPlotter.
+  window.smoothPlotter = smoothPlotter;
+  Dygraph.smoothPlotter = smoothPlotter;
 })();

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -36,8 +36,8 @@
   "use strict";
 
   var Dygraph;
-  if (window?.Dygraph) {
-    Dygraph = window?.Dygraph;
+  if (window.Dygraph) {
+    Dygraph = window.Dygraph;
   } else if (typeof module !== "undefined") {
     Dygraph = require("../dygraph");
   }

--- a/src/plugins/range-selector.js
+++ b/src/plugins/range-selector.js
@@ -540,7 +540,7 @@ rangeSelector.prototype.initInteraction_ = function () {
   );
   this.setDefaultOption_("panEdgeFraction", 0.0001);
 
-  var dragStartEvent = window?.opera ? "mousedown" : "dragstart";
+  var dragStartEvent = window.opera ? "mousedown" : "dragstart";
   this.dygraph_.addAndTrackEvent(
     this.leftZoomHandle_,
     dragStartEvent,


### PR DESCRIPTION
Extended Dygraph to render the annotations in the first pass if the annotations are passed in with `options.annotations`. This should not break anything related to RW because we know which annotations exist before we need to render the graph.